### PR TITLE
Use built-in tuple debug formatter

### DIFF
--- a/src/gzip.rs
+++ b/src/gzip.rs
@@ -192,35 +192,31 @@ impl From<u8> for Flags {
 
 impl fmt::Debug for Flags {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Flags(")?;
-        let mut first = true;
-        let mut item = |s: &str| {
-            if first {
-                first = false;
-                write!(f, "{}", s)
-            } else {
-                write!(f, ", {}", s)
-            }
-        };
+        let mut t = f.debug_tuple("Flags");
 
         if self.has(Flags::FTEXT) {
-            item("TEXT")?;
+            t.field(&format_args!("TEXT"));
         }
         if self.has(Flags::FHCRC) {
-            item("HCRC")?;
+            t.field(&format_args!("HCRC"));
         }
         if self.has(Flags::FEXTRA) {
-            item("EXTRA")?;
+            t.field(&format_args!("EXTRA"));
         }
         if self.has(Flags::FNAME) {
-            item("NAME")?;
+            t.field(&format_args!("NAME"));
         }
         if self.has(Flags::FCOMMENT) {
-            item("COMMENT")?;
+            t.field(&format_args!("COMMENT"));
         }
-        write!(f, ")")?;
-        Ok(())
+
+        t.finish()
     }
+}
+
+#[test]
+fn custom_flags_debug() {
+    assert_eq!("Flags(TEXT, HCRC, EXTRA, NAME, COMMENT)", format!("{:?}", Flags::from(0b11111)))
 }
 
 impl std::ops::BitAnd for Flags {


### PR DESCRIPTION
This replaces the clever and custom-made debug impl of `gzip::Flags` with one that uses Rust's built-in [`DebugTuple`] formatter.

The advantages are that the code is less clever, may seem more familiar to Rust devs, and that is will automatically support 'alternate mode' (`{:#?}`, breaking up the fields over multiple lines).

The disadvantages are that we have to resort to a weird `&format_args!("..")` dance (because the param given to `.field` needs to be `&dyn Debug`) and that the alternate mode support doesn't seem very useful here.

[`DebugTuple`]: https://doc.rust-lang.org/1.36.0/std/fmt/struct.DebugTuple.html